### PR TITLE
Add baseline test suite, pytest CI, grouped Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,5 +6,10 @@ updates:
       interval: "weekly"
       day: "tuesday"
     target-branch: "develop"
+    groups:
+      patch-and-minor:
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - "dependencies"

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -1,0 +1,25 @@
+name: PyTest
+on: push
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: astral-sh/setup-uv@v5
+        with:
+          enable-cache: true
+          python-version: "3.13"
+
+      - name: Install packages
+        run: uv sync --all-extras --dev
+
+      - name: Run tests
+        run: uv run pytest tests
+        env:
+          CI: true

--- a/pyobs_gemini/gemini.py
+++ b/pyobs_gemini/gemini.py
@@ -79,7 +79,7 @@ class GeminiFocuserRotator(
 
         # SERIAL CONFIGURATION DICTIONARY
         if serial_config is None:
-            self._serial_config = {
+            self._serial_config: dict[str, Any] = {
                 "port": "/dev/ttyUSB0",
                 "baudrate": 115200,
                 "timeout": 0.1,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,8 @@ dev = [
     "pre-commit>=4.2.0,<5",
     "ruff>=0.9.0",
     "pyrefly>=1.1.1",
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.24.0",
 ]
 
 [tool.uv.build-backend]
@@ -44,3 +46,6 @@ select = ["E", "F", "W", "I", "UP", "G"]
 [tool.pyrefly]
 python-version = "3.11"
 ignore-missing-imports = []
+
+[tool.pytest.ini_options]
+asyncio_mode = "strict"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,46 @@
+"""Unit tests for the pure GEMINI command/response API (no serial I/O)."""
+
+import pytest
+
+from pyobs_gemini.api import gemini_cmd, gemini_parse_output
+
+
+def test_cmd_without_args() -> None:
+    assert gemini_cmd("DOHOME", dev="F", trans_id=1) == "<F101DOHOME>"
+
+
+def test_cmd_with_arg() -> None:
+    assert gemini_cmd("MOVABS", 1000, dev="F", trans_id=1) == "<F101MOVABS1000>"
+
+
+def test_cmd_padded_arg() -> None:
+    assert gemini_cmd("SETREV", 1, dev="R", trans_id=5) == "<R105SETREV1>"
+
+
+def test_cmd_unknown_command() -> None:
+    with pytest.raises(ValueError):
+        gemini_cmd("NOPE", dev="F")
+
+
+def test_cmd_wrong_device() -> None:
+    with pytest.raises(ValueError):
+        gemini_cmd("MOVABS", 1000, dev="R")
+
+
+def test_parse_getsta() -> None:
+    raw = [b"!01\n", b"CurentPA = 180000\n", b"CurrStep = 12345\n", b"END\n"]
+    results, errors = gemini_parse_output("GETSTA", raw)
+    assert errors == {}
+    assert results["trans_id"] == 1
+    assert results["CurentPA"] == 180000
+    assert results["CurrStep"] == 12345
+
+
+def test_parse_bad_response() -> None:
+    with pytest.raises(ValueError):
+        gemini_parse_output("GETSTA", [b"not a gemini response\n"])
+
+
+def test_parse_unknown_command() -> None:
+    with pytest.raises(ValueError):
+        gemini_parse_output("NOPE", [b"!01\n"])

--- a/tests/test_geminidriver.py
+++ b/tests/test_geminidriver.py
@@ -1,0 +1,75 @@
+"""Unit tests for the pure conversion logic in GeminiDriver, with the serial port
+mocked out. Hardware I/O (talking to the device) is out of scope.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import numpy as np
+import pytest
+
+from pyobs_gemini.geminidriver import GeminiDriver, GeminiTransaction, dict_union, has_transaction_error
+
+
+def make_driver() -> GeminiDriver:
+    with patch("aioserial.AioSerial"):
+        return GeminiDriver()
+
+
+def test_steps_to_mm_and_clamp() -> None:
+    driver = make_driver()
+    driver.focus_model = {"offset": 0.0, "scale": 2.0, "min": -100.0, "max": 100.0, "max_steps": 100}
+    assert driver._steps_to_mm(5) == pytest.approx(10.0)
+    assert driver._steps_to_mm(100) == 100.0  # 200 clamped to max
+    assert driver._steps_to_mm(-100) == -100.0  # -200 clamped to min
+
+
+def test_mm_to_steps_and_clamp() -> None:
+    driver = make_driver()
+    driver.focus_model = {"offset": 0.0, "scale": 2.0, "min": -100.0, "max": 100.0, "max_steps": 100}
+    assert driver._mm_to_steps(10.0) == 5
+    assert driver._mm_to_steps(999.0) == 100  # clamped to max_steps
+    assert driver._mm_to_steps(-999.0) == 0  # clamped to 0
+
+
+def test_steps_to_mm_without_model() -> None:
+    driver = make_driver()
+    assert np.isnan(driver._steps_to_mm(5))
+
+
+def test_rotation_conversions() -> None:
+    driver = make_driver()
+    driver.rotation_model = {"offset": -180.0, "scale": 0.001, "min": -180.0, "max": 180.0, "max_steps": 360000}
+    assert driver._intern_to_extern(180000) == pytest.approx(0.0)
+    assert driver._extern_to_intern(0.0) == 180000
+
+
+def test_has_transaction_error() -> None:
+    assert has_transaction_error(None) is True
+
+    transaction = GeminiTransaction()
+    assert has_transaction_error(transaction) is False
+
+    transaction.errors["foo"] = "bar"
+    assert has_transaction_error(transaction) is True
+    assert has_transaction_error(transaction, keys=["baz"]) is False
+    assert has_transaction_error(transaction, keys=["foo"]) is True
+
+
+def test_dict_union() -> None:
+    assert dict_union({"a": 1}, {"b": 2}) == {"a": 1, "b": 2}
+    assert dict_union(None, {"b": 2}) == {"b": 2}
+
+
+@pytest.mark.asyncio
+async def test_calibrate_builds_models() -> None:
+    driver = make_driver()
+    driver.serial = AsyncMock()
+    driver.serial.readlines_async.return_value = [b"!01\n", b"MaxSteps = 100000\n", b"END\n"]
+
+    assert await driver.calibrate() is True
+    assert driver.focus_model is not None
+    assert driver.focus_model["max_steps"] == 100000
+    assert driver.focus_model["scale"] == pytest.approx(60.0 / 100000)
+    assert driver.focus_model["offset"] == pytest.approx(-30.0)
+    assert driver.rotation_model is not None
+    assert driver.rotation_model["max_steps"] == 360000

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -1,0 +1,28 @@
+"""Smoke tests: import every public module and instantiate the driver class without
+hardware, asserting it advertises the interfaces it claims.
+
+No serial device is involved: the GeminiDriver (and its serial port) is only created
+inside open(), so instantiation is safe.
+"""
+
+from pyobs.interfaces import ICalibrate, IFitsHeaderBefore, IFocuser, IPointingRaDec, IRotation
+from pyobs.modules import Module
+
+from pyobs_gemini import GeminiFocuserRotator
+
+
+def test_import_api_and_driver_modules() -> None:
+    from pyobs_gemini import api, geminidriver  # noqa: F401
+
+    assert api.gemini_cmd is not None
+    assert geminidriver.GeminiDriver is not None
+
+
+def test_instantiate_gemini() -> None:
+    gemini = GeminiFocuserRotator()
+    assert isinstance(gemini, Module)
+    assert isinstance(gemini, IRotation)
+    assert isinstance(gemini, IFocuser)
+    assert isinstance(gemini, ICalibrate)
+    assert isinstance(gemini, IPointingRaDec)
+    assert isinstance(gemini, IFitsHeaderBefore)

--- a/uv.lock
+++ b/uv.lock
@@ -694,6 +694,15 @@ wheels = [
 ]
 
 [[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
 name = "invoke"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1105,6 +1114,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
 name = "pre-commit"
 version = "4.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1412,6 +1430,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
 name = "pynacl"
 version = "1.6.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1490,6 +1517,8 @@ dev = [
     { name = "black" },
     { name = "pre-commit" },
     { name = "pyrefly" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
 
@@ -1506,6 +1535,8 @@ dev = [
     { name = "black", specifier = ">=25.1.0,<27" },
     { name = "pre-commit", specifier = ">=4.2.0,<5" },
     { name = "pyrefly", specifier = ">=1.1.1" },
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", specifier = ">=0.24.0" },
     { name = "ruff", specifier = ">=0.9.0" },
 ]
 
@@ -1535,6 +1566,35 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1e/7d/ae3f0a63f41e4d2f6cb66a5b57197850f919f59e558159a4dd3a818f5082/pyserial-3.5.tar.gz", hash = "sha256:3c77e014170dfffbd816e6ffc205e9842efb10be9f58ec16d3e8675b4925cddb", size = 159125, upload-time = "2020-11-23T03:59:15.045Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/07/bc/587a445451b253b285629263eb51c2d8e9bcea4fc97826266d186f96f558/pyserial-3.5-py2.py3-none-any.whl", hash = "sha256:c4451db6ba391ca6ca299fb3ec7bae67a5c55dde170964c7a14ceefec02f2cf0", size = 90585, upload-time = "2020-11-23T03:59:13.41Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/47/b9efed96c114afcfa3c9d3fe98a76a1d14c74a9e266d397cf6eb64be5e01/pytest-9.1.1.tar.gz", hash = "sha256:1088fbde8f2b49d95a549a195707afa7a76a3ce9bcadc26b6d71f0ffda5fe313", size = 1636369, upload-time = "2026-06-19T10:58:32.857Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/25/1de2678b631f5a49215c6c96fff41ba892b0a34df68d6d80292b1b48aa7f/pytest-9.1.1-py3-none-any.whl", hash = "sha256:37a86b45efb9a47a61a36449063e8e18d0cab3161329fc099eb21783169c4f0c", size = 386536, upload-time = "2026-06-19T10:58:31.347Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/7c/d36d04db312ecf4298932ef77e6e4a9e8ad017906e24e34f0b0c361a2473/pytest_asyncio-1.4.0.tar.gz", hash = "sha256:c6c0d2259945122819f171a32ecea2c349ead889ee28176caaf492143424be42", size = 58514, upload-time = "2026-05-26T09:56:04.083Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/03/e2/08a497ef684b88559c9cc5f4ad53a37e7b99e727094a86d6ea32536d5d3c/pytest_asyncio-1.4.0-py3-none-any.whl", hash = "sha256:933ca923a23075a87fb7070c0ec272a6848489824d887c85c812670932835aa1", size = 16930, upload-time = "2026-05-26T09:56:02.576Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Part of pyobs-core#752 (core-tier test baseline + Dependabot auto-merge). Third repo in the rollout order.

**What's here**
- `tests/test_import.py`: import every public module + instantiate `GeminiFocuserRotator`, assert interfaces (`IRotation`, `IFocuser`, `ICalibrate`, `IPointingRaDec`, `IFitsHeaderBefore`).
- `tests/test_api.py`: `gemini_cmd` command construction + `gemini_parse_output` response parsing (pure, no serial).
- `tests/test_geminidriver.py`: steps↔mm and rotation conversions, `calibrate()` model derivation, transaction-error helpers, all with the serial port mocked.
- `pytest` + `pytest-asyncio` in dev deps, `pytest.yml` workflow, Dependabot patch/minor grouping. (`pyrefly.yml` already existed.)

**Pre-existing bug fixed along the way**
The develop `pyrefly` job has been red: `_serial_config` was inferred as `dict[str, str|int|float]`, so `GeminiDriver(**self._serial_config)` in `open()` failed `bad-argument-type` on the `port`/`baudrate`/`timeout` params. Annotated it `dict[str, Any]`. `pyrefly check` is now 0 errors.

Local checks: `uv run pytest tests` (17 passed), `ruff check`, `pyrefly check`, `black --check` all green.