### PR TITLE
Convert GeminiFocuserRotator to cooperative super() init chain

### DIFF
--- a/pyobs_gemini/gemini.py
+++ b/pyobs_gemini/gemini.py
@@ -30,9 +30,9 @@ log = logging.getLogger(__name__)
 
 
 class GeminiFocuserRotator(
+    Module,
     FitsNamespaceMixin,
     MotionStatusMixin,
-    Module,
     IRotation,
     IFocuser,
     ICalibrate,
@@ -50,7 +50,7 @@ class GeminiFocuserRotator(
         *args: Any,
         **kwargs: Any,
     ):
-        Module.__init__(self, *args, **kwargs)
+        super().__init__(*args, motion_status_interfaces=["IFocuser", "IRotation"], **kwargs)
 
         # add thread func
         self.add_background_task(self._gdriver_update_func, True)
@@ -109,10 +109,6 @@ class GeminiFocuserRotator(
             }
         else:
             self._fits_config = fits_config
-
-        # mixins
-        FitsNamespaceMixin.__init__(self, *args, **kwargs)
-        MotionStatusMixin.__init__(self, **kwargs, motion_status_interfaces=["IFocuser", "IRotation"])
 
     async def open(self) -> None:
         """Open module."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "aioserial>=1.3,<2",
     "astropy>=7.0.1,<9",
     "numpy>=2.2.5,<3",
-    "pyobs-core>=2.0.0.dev48,<3",
+    "pyobs-core>=2.0.0.dev82,<3",
 ]
 
 [dependency-groups]

--- a/tests/test_import.py
+++ b/tests/test_import.py
@@ -26,3 +26,21 @@ def test_instantiate_gemini() -> None:
     assert isinstance(gemini, ICalibrate)
     assert isinstance(gemini, IPointingRaDec)
     assert isinstance(gemini, IFitsHeaderBefore)
+
+
+def test_constructor_threads_mixin_kwargs_cooperatively() -> None:
+    """Regression test for the cooperative-super()-chain fix: GeminiFocuserRotator(Module,
+    FitsNamespaceMixin, MotionStatusMixin, ...) used to call Module.__init__ first, then
+    FitsNamespaceMixin.__init__/MotionStatusMixin.__init__ explicitly at the end -- the live
+    gemini.yaml config sets fits_namespaces, which must still reach FitsNamespaceMixin through
+    the single super().__init__() call, not get lost or leak to object.__init__(). If either
+    mixin's __init__ never actually ran, motion_status()/_filter_fits_namespace() below raise
+    AttributeError instead of returning a value."""
+    from pyobs.utils.enums import MotionStatus
+
+    gemini = GeminiFocuserRotator(fits_namespaces={"sbig8300": None}, rotation_offset=90.0)
+
+    assert gemini.motion_status() == MotionStatus.UNKNOWN
+    filtered = gemini._filter_fits_namespace({}, sender="sbig8300")
+    assert filtered == {}
+    assert gemini._rotation_offset == 90.0

--- a/uv.lock
+++ b/uv.lock
@@ -1463,7 +1463,7 @@ wheels = [
 
 [[package]]
 name = "pyobs-core"
-version = "2.0.0.dev72"
+version = "2.0.0.dev82"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1495,9 +1495,9 @@ dependencies = [
     { name = "tenacity" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d7/25/ac1a0571461eb87655374a38a4a21983db407f7239d60adce009e4ba8438/pyobs_core-2.0.0.dev72.tar.gz", hash = "sha256:b9ac8679bb9a72d1180ba60a97ad08b1878b1bc6b21158754d1f7fc7033231ee", size = 354347, upload-time = "2026-08-10T11:31:59.746Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/b8/e0d2a5fa390e15eebd01c86a75360e47e72823036b9e8793f73961c4e24a/pyobs_core-2.0.0.dev82.tar.gz", hash = "sha256:eb5e6510e0ba113700876db409cdce4b5d57e6df399421fc8cf174ec9e5076a8", size = 362959, upload-time = "2026-08-19T04:27:17.94Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8e/6a/570856f6149a611d7e4858e980faa1e23c5ddedda22327808f8e3eb5b413/pyobs_core-2.0.0.dev72-py3-none-any.whl", hash = "sha256:321f6b80f2fb8703e3cbf2f62cea2333cb475b1a50f58d8900176644fe6ca6b2", size = 576647, upload-time = "2026-08-10T11:31:57.813Z" },
+    { url = "https://files.pythonhosted.org/packages/81/17/83f22b85cfd9dea2c18396738d12fcd631232b2e8a111700133b037a7673/pyobs_core-2.0.0.dev82-py3-none-any.whl", hash = "sha256:b0cfe7d7a9dff89a8650ff4c01cdd3423f8ca9188aeef1d799d3e61085484bb2", size = 585768, upload-time = "2026-08-19T04:27:16.531Z" },
 ]
 
 [[package]]
@@ -1527,7 +1527,7 @@ requires-dist = [
     { name = "aioserial", specifier = ">=1.3,<2" },
     { name = "astropy", specifier = ">=7.0.1,<9" },
     { name = "numpy", specifier = ">=2.2.5,<3" },
-    { name = "pyobs-core", specifier = ">=2.0.0.dev48,<3" },
+    { name = "pyobs-core", specifier = ">=2.0.0.dev82,<3" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
## Summary

- `GeminiFocuserRotator` composed `Module`, `FitsNamespaceMixin` and `MotionStatusMixin` via
  explicit, separate `__init__` calls sharing the same unfiltered `**kwargs` dict (a "fan-out"
  pattern) -- see `pyobs-core`'s [specs/plans/2026-08-18-cooperative-mixin-init.md](https://github.com/pyobs/pyobs-core/blob/develop/specs/plans/2026-08-18-cooperative-mixin-init.md).
- Now that `pyobs-core`'s `Object`/`Module` forward via `super().__init__(**kwargs)` (pyobs-core
  PR #776), `Module.__init__` running first (line 53) leaks any `FitsNamespaceMixin`-only kwarg
  (`fits_namespaces`) past `FitsNamespaceMixin.__init__` -- called last, at line 114, too late --
  all the way to `object.__init__()`, which raises `TypeError`.
- **Not hypothetical**: the live `pyobs-monet/config/south/piggyback/gemini.yaml` config sets
  `fits_namespaces` explicitly. This would fail to construct the moment `pyobs-gemini` bumps its
  `pyobs-core` pin past #776.
- Fix: reorder bases so `Module` runs first, collapse the fan-out to a single
  `super().__init__()` call moved to the top of `__init__` (ahead of this class's own attribute
  setup, matching the `BaseTelescope` precedent from `pyobs-core`'s own fix), threading
  `motion_status_interfaces` as the derived value it always was.

## Test plan

- [x] `pytest tests/` -- 17/17 passed
- [x] `ruff check` / `black --check` / `pyrefly check` -- clean
- [x] Constructed `GeminiFocuserRotator` from the live `gemini.yaml` config against the fixed
      `pyobs-core` branch -- succeeds, with `fits_namespaces` and `motion_status_interfaces` both
      landing on the right attributes